### PR TITLE
Fix errant <

### DIFF
--- a/lib/html-element.js
+++ b/lib/html-element.js
@@ -47,7 +47,7 @@ HTMLElement.DataTypes = {
     the first complete tag and attributes from the input.
 */
 HTMLElement.RegExp = {
-    Text: /[^\<]*/,
+    Text: /[^]+?((?=\<([a-zA-Z_]|\!--))|$)/,
     AttributeName: /[^\s\=\>]+/,
     AttributeValue: /^([^\"\'\>\s]+|\"[^\"]*\"|\'[^\']*\')/,
     Comment: /^\<!--[^]+?(?=--\>)--\>/,

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -521,12 +521,27 @@
                     }
                 ]
             ],
-            "testErrantLessThanInHTML": [
+            "testErrantLessThanInText": [
                 "Here's some love <3! :D",
                 [
                     {
                         "dataType": "text",
                         "content": "Here's some love <3! :D"
+                    }
+                ]
+            ],
+            "testErrantLessThanInHTML": [
+                "<div>Here's some love <3! :D</div>",
+                [
+                    {
+                        "dataType": "tag",
+                        "content": "div",
+                        "children": [
+                            {
+                                "dataType": "text",
+                                "content": "Here's some love <3! :D"
+                            }
+                        ]
                     }
                 ]
             ]

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -520,6 +520,15 @@
                         "content": "and I kinda feel bad about it"
                     }
                 ]
+            ],
+            "testErrantLessThanInHTML": [
+                "Here's some love <3! :D",
+                [
+                    {
+                        "dataType": "text",
+                        "content": "Here's some love <3! :D"
+                    }
+                ]
             ]
         }
     }


### PR DESCRIPTION
Feels super dirty. Replaces the simple "Match anything but a <" regex that was previously used for grabbing text elements with a more advances "Match anything that doesn't look like it might be an opening tag or a comment". 

Closes #15 
