### PR TITLE
Fixed dashes appearing in attribute names for xpath querying.

### DIFF
--- a/lib/html-element.js
+++ b/lib/html-element.js
@@ -499,7 +499,7 @@ HTMLElement._xpathPredicate = function(filteredElements, predicate) {
         return textElements;
     }
 
-    var attributeMatches = predicate.match(/^@(\w+|\*)(?:\=(.*))?$/);
+    var attributeMatches = predicate.match(/^@([\w\-]+|\*)(?:\=(.*))?$/);
     var attributeName = attributeMatches[1];
     if (attributeMatches[2]) {
         // Has a match for filtering by attribute value.

--- a/tests/bigTests.json
+++ b/tests/bigTests.json
@@ -170,6 +170,10 @@
                                         "class": {
                                             "dataType": "attribute",
                                             "content": "nav fancy"
+                                        },
+                                        "ng-show": {
+                                            "dataType": "attribute",
+                                            "content": "something > 1"
                                         }
                                     },
                                     "children": [

--- a/tests/nav.html
+++ b/tests/nav.html
@@ -17,7 +17,7 @@
                 </li>
             </ul>
         </div>
-        <div class="nav fancy">
+        <div class="nav fancy" ng-show="something > 1">
             <ul>
                 <li>
                     <a id="nav-contact" href="/contact">Contact us</a>

--- a/tests/xpath.js
+++ b/tests/xpath.js
@@ -152,3 +152,10 @@ module.exports.hasDashesInTagName = function(test) {
     test.done();
 };
 
+module.exports.hasDashesInAttributeName = function(test) {
+    var html = fs.readFileSync("./tests/nav.html");
+    var document = HTMLElement.fromString(html.toString());
+    var listElements = document.getElementsByClassName("fancy");
+    test.deepEqual(document.xpath("//div[@ng-show='something > 1']"), listElements);
+    test.done();
+};


### PR DESCRIPTION
If only there was this magical way where I could have regular expressions defined in a nice place where I might notice that there are inconsistencies with certain definitions. 