### PR TITLE
Prevent catastrophic backtracking

### DIFF
--- a/lib/html-element.js
+++ b/lib/html-element.js
@@ -71,7 +71,7 @@ HTMLElement.RegExp.FullTag = new RegExp(
             ")?" + // Optional string value within the whole value.
         ")?" + // Or one with a value.
     ")*" +
-    "\\s*\\>" // Tag close.
+    "\\s*\\>?" // Tag close.
 );
 
 /**
@@ -151,8 +151,10 @@ HTMLElement.processTagFromBufferIntoElements = function(buffer, elements) {
     }
 
     var oneTag = HTMLElement.findTagInString(buffer);
+    var hasEndTag = oneTag.charAt(oneTag.length - 1) === ">";
+
     buffer = buffer.substring(oneTag.length);
-    var tagText = oneTag.substring(1, oneTag.length - 1).trim();
+    var tagText = oneTag.substring(1, oneTag.length - (hasEndTag ? 1 : 0)).trim();
 
     var element = new HTMLElement(HTMLElement.DataTypes.Tag);
 

--- a/lib/html-element.js
+++ b/lib/html-element.js
@@ -49,7 +49,7 @@ HTMLElement.DataTypes = {
 HTMLElement.RegExp = {
     Text: /[^]+?((?=\<([a-zA-Z_]|\!--))|$)/,
     AttributeName: /[^\s\=\>]+/,
-    AttributeValue: /^([^\"\'\>\s]+|\"[^\"]*\"|\'[^\']*\')/,
+    AttributeValue: /^[^\"\'\>\s]+|\"[^\"]*\"|\'[^\']*\'/,
     Comment: /^\<!--[^]+?(?=--\>)--\>/,
     XPath: {
         ChildNodeSearch: /^\/(@?[\w\-]+|\*)/,

--- a/lib/html-element.js
+++ b/lib/html-element.js
@@ -69,7 +69,7 @@ HTMLElement.RegExp.FullTag = new RegExp(
             "(" +
                 HTMLElement.RegExp.AttributeValue.source.substring(1) +
             ")?" + // Optional string value within the whole value.
-        "\\s*)?" + // Or one with a value.
+        ")?" + // Or one with a value.
     ")*" +
     "\\s*\\>" // Tag close.
 );

--- a/lib/html-element.js
+++ b/lib/html-element.js
@@ -65,7 +65,7 @@ HTMLElement.RegExp.FullTag = new RegExp(
         "(\\s*" +
             HTMLElement.RegExp.AttributeName.source + // Attribute Name.
         "\\s*)" +
-        "(\\s*\\=\\s*" + // If there's a "value" there's an =.
+        "(\\=\\s*" + // If there's a "value" there's an =.
             "(" +
                 HTMLElement.RegExp.AttributeValue.source.substring(1) +
             ")?" + // Optional string value within the whole value.

--- a/tests/tests.json
+++ b/tests/tests.json
@@ -544,7 +544,26 @@
                         ]
                     }
                 ]
-            ]
+            ],
+            "testUnterminatedTag": [
+                "<img src=http://somedomain.atld/a/path/to/some/resource attrtwo=123",
+                [
+                    {
+                        "dataType": "tag",
+                        "content": "img",
+                        "attributes": {
+                            "src": {
+                                "dataType": "attribute",
+                                "content": "http://somedomain.atld/a/path/to/some/resource"
+                            },
+                            "attrtwo": {
+                                "dataType": "attribute",
+                                "content": "123"
+                            }
+                        }
+                    }
+                ]
+             ]        
         }
     }
 }


### PR DESCRIPTION
Cleaned up some of the regular expressions, and prevented issues where unterminated tags would cause catastrophic backtracking in the regex engine.